### PR TITLE
Bug fix for email template attributes Dto conversion check

### DIFF
--- a/PSSailpoint/beta/src/PSSailpointBeta/Model/TemplateDto.ps1
+++ b/PSSailpoint/beta/src/PSSailpointBeta/Model/TemplateDto.ps1
@@ -164,7 +164,7 @@ function ConvertFrom-BetaJsonToTemplateDto {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in BetaTemplateDto
-        $AllProperties = ("key", "name", "medium", "locale", "subject", "header", "body", "footer", "from", "replyTo", "description", "id", "created", "modified")
+        $AllProperties = ("key", "name", "medium", "locale", "subject", "header", "body", "footer", "from", "replyTo", "description", "id", "created", "modified", "slackTemplate", "teamsTemplate")
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"

--- a/PSSailpoint/beta/src/PSSailpointBeta/Model/TemplateDtoDefault.ps1
+++ b/PSSailpoint/beta/src/PSSailpointBeta/Model/TemplateDtoDefault.ps1
@@ -134,7 +134,7 @@ function ConvertFrom-BetaJsonToTemplateDtoDefault {
         $JsonParameters = ConvertFrom-Json -InputObject $Json
 
         # check if Json contains properties not defined in BetaTemplateDtoDefault
-        $AllProperties = ("key", "name", "medium", "locale", "subject", "header", "body", "footer", "from", "replyTo", "description")
+        $AllProperties = ("key", "name", "medium", "locale", "subject", "header", "body", "footer", "from", "replyTo", "description", "slackTemplate", "teamsTemplate")
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"


### PR DESCRIPTION
When using `Get-BetaNotificationTemplates`, it returns additional attributes `slackTemplate` and `teamsTemplate` which always seem to be null. `ConvertFrom-BetaJsonToTemplateDto` will not accept these parameters today in the JSON body that is passed, so you need to remove them first before being able to make this call successfully, which is required to call `New-BetaNotificationTemplate -TemplateDto $dto`. Just a small tedious thing when trying to move templates from one tenant to another.

![image](https://github.com/sailpoint-oss/powershell-sdk/assets/14898185/0e756b0e-0adc-4760-97c7-6e2c133c52bd)
