### PR TITLE
Issue #78  - Changed parameter name in PSSailpoint/beta/src/PSSailpointBeta/Model/EntitlementAccessRequestConfig.ps1

### DIFF
--- a/PSSailpoint/beta/src/PSSailpointBeta/Model/EntitlementAccessRequestConfig.ps1
+++ b/PSSailpoint/beta/src/PSSailpointBeta/Model/EntitlementAccessRequestConfig.ps1
@@ -33,7 +33,7 @@ function Initialize-BetaEntitlementAccessRequestConfig {
         ${ApprovalSchemes},
         [Parameter(ValueFromPipelineByPropertyName = $true)]
         [System.Nullable[Boolean]]
-        ${RequestCommentRequired} = $false,
+        ${CommentsRequired} = $false,
         [Parameter(ValueFromPipelineByPropertyName = $true)]
         [System.Nullable[Boolean]]
         ${DenialCommentRequired} = $false
@@ -46,7 +46,7 @@ function Initialize-BetaEntitlementAccessRequestConfig {
 
         $PSO = [PSCustomObject]@{
             "approvalSchemes" = ${ApprovalSchemes}
-            "requestCommentRequired" = ${RequestCommentRequired}
+            "commentsRequired" = ${CommentsRequired}
             "denialCommentRequired" = ${DenialCommentRequired}
         }
 


### PR DESCRIPTION
Updated parameter name RequestCommentRequired to CommentsRequired to match the API spec for Create Access Profile