### PR TITLE
Removal of references to [System.Nullable[String]]

### DIFF
--- a/PSSailpoint/v3/src/PSSailpoint/Model/Search.ps1
+++ b/PSSailpoint/v3/src/PSSailpoint/Model/Search.ps1
@@ -62,7 +62,7 @@ function Initialize-Search {
         [PSCustomObject]
         ${QueryType},
         [Parameter(ValueFromPipelineByPropertyName = $true)]
-        [System.Nullable[String]]
+        [AllowNull()]
         ${QueryVersion},
         [Parameter(ValueFromPipelineByPropertyName = $true)]
         [PSCustomObject]
@@ -87,7 +87,7 @@ function Initialize-Search {
         [PSCustomObject]
         ${AggregationType},
         [Parameter(ValueFromPipelineByPropertyName = $true)]
-        [System.Nullable[String]]
+        [AllowNull()]
         ${AggregationsVersion},
         [Parameter(ValueFromPipelineByPropertyName = $true)]
         [PSCustomObject]


### PR DESCRIPTION
Using the Initialize-Search function instead of ConvertFrom-JSONToSearch in order to create the PSObject for search results in the following error

![image](https://github.com/user-attachments/assets/3ec3a3d5-cf49-4aa3-88f9-420471eb0b15)

Replacing the references of [System.Nullable[String]] to [AllowNull()] fixes this