### PR TITLE
Fix for "Start-V2025SodPolicy fails with MethodNotAllowed"

### DIFF
--- a/PSSailpoint/beta/src/PSSailpoint.Beta/Api/BetaSODPoliciesApi.ps1
+++ b/PSSailpoint/beta/src/PSSailpoint.Beta/Api/BetaSODPoliciesApi.ps1
@@ -1341,6 +1341,9 @@ function Start-BetaSodPolicy {
         # HTTP header 'Accept' (if needed)
         $LocalVarAccepts = @('application/json')
 
+        # HTTP header 'Content-Type'
+        $LocalVarContentTypes = @('application/json')
+
         $LocalVarUri = '/sod-policies/{id}/violation-report/run'
         if (!$Id) {
             throw "Error! The required parameter `Id` missing when calling startSodPolicy."

--- a/PSSailpoint/v2024/src/PSSailpoint.V2024/Api/V2024SODPoliciesApi.ps1
+++ b/PSSailpoint/v2024/src/PSSailpoint.V2024/Api/V2024SODPoliciesApi.ps1
@@ -1415,6 +1415,9 @@ function Start-V2024SodPolicy {
         # HTTP header 'Accept' (if needed)
         $LocalVarAccepts = @('application/json')
 
+        # HTTP header 'Content-Type'
+        $LocalVarContentTypes = @('application/json')
+        
         $LocalVarUri = '/sod-policies/{id}/violation-report/run'
         if (!$Id) {
             throw "Error! The required parameter `Id` missing when calling startSodPolicy."

--- a/PSSailpoint/v2025/src/PSSailpoint.V2025/Api/V2025SODPoliciesApi.ps1
+++ b/PSSailpoint/v2025/src/PSSailpoint.V2025/Api/V2025SODPoliciesApi.ps1
@@ -1415,6 +1415,9 @@ function Start-V2025SodPolicy {
         # HTTP header 'Accept' (if needed)
         $LocalVarAccepts = @('application/json')
 
+        # HTTP header 'Content-Type'
+        $LocalVarContentTypes = @('application/json')
+        
         $LocalVarUri = '/sod-policies/{id}/violation-report/run'
         if (!$Id) {
             throw "Error! The required parameter `Id` missing when calling startSodPolicy."

--- a/PSSailpoint/v3/src/PSSailpoint.V3/Api/SODPoliciesApi.ps1
+++ b/PSSailpoint/v3/src/PSSailpoint.V3/Api/SODPoliciesApi.ps1
@@ -1415,6 +1415,9 @@ function Start-SodPolicy {
         # HTTP header 'Accept' (if needed)
         $LocalVarAccepts = @('application/json')
 
+        # HTTP header 'Content-Type'
+        $LocalVarContentTypes = @('application/json')
+        
         $LocalVarUri = '/sod-policies/{id}/violation-report/run'
         if (!$Id) {
             throw "Error! The required parameter `Id` missing when calling startSodPolicy."


### PR DESCRIPTION
added the content types in the various SODPoliciesApi.ps1 for issue:
Start-V2025SodPolicy fails with MethodNotAllowed 
https://github.com/sailpoint-oss/powershell-sdk/issues/139

