### PR TITLE
Fix 12 bugs in hand-written files, templates, and build scripts

### DIFF
--- a/PSSailpoint/Configuration.ps1
+++ b/PSSailpoint/Configuration.ps1
@@ -146,7 +146,7 @@ function Set-DefaultConfiguration {
         If ($BaseUrl) {
             # validate URL
             $URL = $BaseUrl -as [System.URI]
-            if (!($null -ne $URL.AbsoluteURI -and $URL.Scheme -match '[http|https]')) {
+            if (!($null -ne $URL.AbsoluteURI -and $URL.Scheme -match '^https?$')) {
                 throw "Invalid URL '$($BaseUrl)' cannot be used in the base URL."
             }
             $Script:Configuration["BaseUrl"] = $BaseUrl
@@ -172,15 +172,15 @@ function Set-DefaultConfiguration {
             $Script:Configuration['ClientSecret'] = $ClientSecret
         }
 
-        If ($RetryIntervalSeconds) {
+        If ($PSBoundParameters.ContainsKey('RetryIntervalSeconds')) {
             $Script:Configuration['RetryIntervalSeconds'] = $RetryIntervalSeconds
         }
 
-        If ($MaximumRetryCount) {
+        If ($PSBoundParameters.ContainsKey('MaximumRetryCount')) {
             $Script:Configuration['MaximumRetryCount'] = $MaximumRetryCount
         }
 
-        If ($Experimental) {
+        If ($PSBoundParameters.ContainsKey('Experimental')) {
             $Script:Configuration['Experimental'] = $Experimental
         }
 
@@ -189,7 +189,7 @@ function Set-DefaultConfiguration {
                 throw "Incorrect Proxy type '$($Proxy.GetType().FullName)'. Must be System.Net.WebProxy or System.Net.SystemWebProxy or System.Net.WebRequest+WebProxyWrapperOpaque."
             }
             $Script:Configuration['Proxy'] = $Proxy
-        } else {
+        } elseif ($PSBoundParameters.ContainsKey('Proxy')) {
             $Script:Configuration['Proxy'] = $null
         }
 
@@ -321,5 +321,5 @@ function Get-Config {
         return $LocalConfig
     }
 
-    return $Configuration
+    return $Script:Configuration
 }

--- a/PSSailpoint/Pagination.ps1
+++ b/PSSailpoint/Pagination.ps1
@@ -71,10 +71,12 @@ function Invoke-PaginateSearch {
     Param(
         [Parameter(Mandatory = $false)]
         [ValidateNotNull()]
-        [ValidateScript({ ($_.sort | Measure-Object).Count -eq 1 }, 
+        [ValidateScript({ ($_.sort | Measure-Object).Count -eq 1 },
             ErrorMessage = "Error! The required `Search` parameter must include exactly one sort parameter to paginate properly.")]
         [PSCustomObject]
         $Search,
+        [Parameter(Mandatory = $false)]
+        [string]$Function = "Search-Post",
         [Int32]$Increment = 250,
         [Int32]$Limit = 10000,
         [Switch]$WithHttpInfo
@@ -101,7 +103,7 @@ function Invoke-PaginateSearch {
                 Write-Debug "SearchAfter=$SearchAfter"
             }
             
-            $Result = Search-Post -Limit $Increment -Search $Search -WithHttpInfo
+            $Result = & $Function -Limit $Increment -Search $Search -WithHttpInfo
             
             Write-Debug "Retrieved $(($Result.Response | Measure-Object).Count) Results"
             

--- a/PSSailpoint/tests/Validation.Tests.ps1
+++ b/PSSailpoint/tests/Validation.Tests.ps1
@@ -21,7 +21,7 @@ Describe 'V3' {
                 "identities"
             ],
             "query": {
-                "query": "*",
+                "query": "*"
             },
             "sort": ["-name"]
         }
@@ -46,7 +46,7 @@ Describe 'V3' {
 
 Describe 'Beta' {
     It 'Returns results for Get-BetaAccounts' {
-        $Response = Get-Accounts -WithHttpInfo
+        $Response = Get-BetaAccounts -WithHttpInfo
         
         $Response.Response | Should -Not -BeNullOrEmpty
         $Response.StatusCode | Should -Be 200

--- a/sdk-resources/postscript.js
+++ b/sdk-resources/postscript.js
@@ -67,9 +67,7 @@ const createDir = async (srcDir, dirName) => {
 
 const moveFiles = async (srcPath, destPath, filename = null) => {
   try {
-    if (!await fs.stat(destPath)) {
-      await fs.mkdir(destPath, { recursive: true });
-    }
+    await fs.mkdir(destPath, { recursive: true });
 
     if (filename) {
       const filePath = path.join(srcPath, filename);

--- a/sdk-resources/resources/api_client.mustache
+++ b/sdk-resources/resources/api_client.mustache
@@ -104,7 +104,7 @@ function Invoke-{{{apiNamePrefix}}}ApiClient {
     # construct URL query string
     $HttpValues = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
     foreach ($Parameter in $QueryParameters.GetEnumerator()) {
-        if ($Parameter.Value.Count -gt 1) { // array
+        if ($Parameter.Value.Count -gt 1) { # array
             foreach ($Value in $Parameter.Value) {
                 $HttpValues.Add($Parameter.Key + '[]', $Value)
             }

--- a/sdk-resources/resources/configuration.mustache
+++ b/sdk-resources/resources/configuration.mustache
@@ -132,7 +132,7 @@ function Set-{{{apiNamePrefix}}}Configuration {
         If ($BaseUrl) {
             # validate URL
             $URL = $BaseUrl -as [System.URI]
-            if (!($null -ne $URL.AbsoluteURI -and $URL.Scheme -match '[http|https]')) {
+            if (!($null -ne $URL.AbsoluteURI -and $URL.Scheme -match '^https?$')) {
                 throw "Invalid URL '$($BaseUrl)' cannot be used in the base URL."
             }
             $Script:Configuration["BaseUrl"] = $BaseUrl

--- a/sdk-resources/resources/model_anyof.mustache
+++ b/sdk-resources/resources/model_anyof.mustache
@@ -68,7 +68,7 @@ function ConvertFrom-{{{apiNamePrefix}}}JsonTo{{{classname}}} {
         {{/mappedModels}}
         {{/discriminator}}
         {{#anyOf}}
-        if ($match -ne 0) { # no match yet
+        if ($match -eq 0) { # no match yet
             # try to match {{{.}}} defined in the anyOf schemas
             try {
                 $matchInstance = ConvertFrom-{{{apiNamePrefix}}}JsonTo{{{.}}} $Json


### PR DESCRIPTION
## Summary

Cross-SDK audit identified 12 bugs in the PowerShell SDK across hand-written files, mustache templates, and build scripts. Template fixes will propagate to generated code on next `make build`.

## Bug Fixes

### Critical

**PS1: C-style `//` comment is invalid PowerShell — causes runtime error on array query params**
- [`sdk-resources/resources/api_client.mustache` L107](https://github.com/sailpoint-oss/powershell-sdk/blob/fix/cross-sdk-bug-fixes/sdk-resources/resources/api_client.mustache#L107): `if ($Parameter.Value.Count -gt 1) { // array` — PowerShell doesn't support `//` comments. This causes a parse error whenever an API call includes array-valued query parameters.
- **Fix:** Changed `//` to `#`.

**PS2: Inverted anyOf match condition breaks all anyOf deserialization**
- [`sdk-resources/resources/model_anyof.mustache` L71](https://github.com/sailpoint-oss/powershell-sdk/blob/fix/cross-sdk-bug-fixes/sdk-resources/resources/model_anyof.mustache#L71): `if ($match -ne 0)` — `$match` starts at 0 and increments on match. The condition `-ne 0` is `$false` on the first iteration, so the first anyOf type is never attempted, and no subsequent types can match either.
- **Fix:** Changed to `if ($match -eq 0)`.

**PS3: `Get-Config` returns undefined local `$Configuration` instead of script-scoped variable**
- [`PSSailpoint/Configuration.ps1` L324](https://github.com/sailpoint-oss/powershell-sdk/blob/fix/cross-sdk-bug-fixes/PSSailpoint/Configuration.ps1#L324): `return $Configuration` returns an undefined local variable. When neither env nor local config succeeds, this returns `$null`, causing a null reference on `$Configuration.BaseUrl[-1]` in `Get-DefaultConfiguration`.
- **Fix:** Changed to `return $Script:Configuration`.

### Medium

**PS4: URL validation regex `'[http|https]'` is a character class, not alternation**
- [`PSSailpoint/Configuration.ps1` L149](https://github.com/sailpoint-oss/powershell-sdk/blob/fix/cross-sdk-bug-fixes/PSSailpoint/Configuration.ps1#L149): `[http|https]` matches individual characters `h`, `t`, `p`, `s`, `|` — not the strings "http" or "https". This accepts URLs with schemes like `ftp`, `ssh`, etc.
- **Fix:** Changed to `'^https?$'`.

**PS5: Cannot set `$Experimental` to `$false`, or retry values to `0`**
- [`PSSailpoint/Configuration.ps1` L175, L179, L183](https://github.com/sailpoint-oss/powershell-sdk/blob/fix/cross-sdk-bug-fixes/PSSailpoint/Configuration.ps1#L175): `If ($Experimental)`, `If ($MaximumRetryCount)`, `If ($RetryIntervalSeconds)` all skip falsy values (`$false`, `0`).
- **Fix:** Changed each to `If ($PSBoundParameters.ContainsKey('...'))`.

**PS6: Proxy cleared unconditionally when not passed to `Set-DefaultConfiguration`**
- [`PSSailpoint/Configuration.ps1` L192-194](https://github.com/sailpoint-oss/powershell-sdk/blob/fix/cross-sdk-bug-fixes/PSSailpoint/Configuration.ps1#L192): The `else` branch of the proxy check sets `$Script:Configuration['Proxy'] = $null` even when the user didn't pass `-Proxy` at all, clearing any previously configured proxy.
- **Fix:** Changed `else` to `elseif ($PSBoundParameters.ContainsKey('Proxy'))`.

**PS7: Same regex bug as PS4 in generated configuration template**
- [`sdk-resources/resources/configuration.mustache` L135](https://github.com/sailpoint-oss/powershell-sdk/blob/fix/cross-sdk-bug-fixes/sdk-resources/resources/configuration.mustache#L135): Same `'[http|https]'` character class bug.
- **Fix:** Changed to `'^https?$'`.

### Low

**PS8 + PS9: Hardcoded `Search-Post` and undefined `$Function` in `Invoke-PaginateSearch`**
- [`PSSailpoint/Pagination.ps1` L104](https://github.com/sailpoint-oss/powershell-sdk/blob/fix/cross-sdk-bug-fixes/PSSailpoint/Pagination.ps1#L105): The search function was hardcoded to `Search-Post`, making it impossible to paginate Beta/V2024/V2025/V2026 search endpoints. The catch block also referenced `$Function` which was undefined.
- **Fix:** Added an optional `$Function` parameter (default `"Search-Post"` for backward compatibility) and use `& $Function` to invoke it dynamically. This also resolves the undefined `$Function` in the error handler.

**PS10: Beta test calls V3 `Get-Accounts` instead of `Get-BetaAccounts`**
- [`PSSailpoint/tests/Validation.Tests.ps1` L49](https://github.com/sailpoint-oss/powershell-sdk/blob/fix/cross-sdk-bug-fixes/PSSailpoint/tests/Validation.Tests.ps1#L49): The Beta describe block's "Get-BetaAccounts" test was actually calling the V3 `Get-Accounts` function.
- **Fix:** Changed to `Get-BetaAccounts`.

**PS11: Trailing comma in JSON test fixture causes parse error**
- [`PSSailpoint/tests/Validation.Tests.ps1` L25](https://github.com/sailpoint-oss/powershell-sdk/blob/fix/cross-sdk-bug-fixes/PSSailpoint/tests/Validation.Tests.ps1#L25): Trailing comma after `"query": "*"` is invalid JSON and causes `ConvertFrom-JsonToSearch` to fail.
- **Fix:** Removed the trailing comma.

**PS12: Broken `fs.stat()` check in `moveFiles()` in postscript.js**
- [`sdk-resources/postscript.js` L70](https://github.com/sailpoint-oss/powershell-sdk/blob/fix/cross-sdk-bug-fixes/sdk-resources/postscript.js#L70): Same issue as Go SDK — `fs.stat()` throws on missing path instead of returning falsy.
- **Fix:** Replaced with `await fs.mkdir(destPath, { recursive: true })`.

## Verification

- Template fixes (PS1, PS2, PS7) verified by source inspection; will take effect on next `make build`
- Hand-written file changes verified by syntax inspection

## Test plan

- [ ] Run `Import-Module ./PSSailpoint/PSSailpoint.psm1` to verify module loads
- [ ] Test API call with array query parameters to verify PS1 fix
- [ ] Test anyOf deserialization (e.g., a model using anyOf schemas) to verify PS2 fix
- [ ] Run `Invoke-Pester` to verify test fixes (PS10, PS11)
- [ ] Test `Set-DefaultConfiguration -Experimental $false` to verify PS5 fix
- [ ] Test `Set-DefaultConfiguration -BaseUrl "ftp://evil"` is rejected by PS4 fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)